### PR TITLE
Issues with bots unlinking

### DIFF
--- a/whatupcore2/pkg/whatupcore2/whatappclient.go
+++ b/whatupcore2/pkg/whatupcore2/whatappclient.go
@@ -141,13 +141,13 @@ func NewWhatsAppClient(username string, passphrase string, log waLog.Logger) (*W
 
 func (wac *WhatsAppClient) setConnectPresence(evt interface{}) {
 	switch evt.(type) {
-	case events.Connected:
+	case *events.Connected:
 		wac.Log.Debugf("Setting presence and active delivery")
-		err := wac.SendPresence(types.PresenceUnavailable)
+		wac.SetForceActiveDeliveryReceipts(true)
+		err := wac.SendPresence(types.PresenceAvailable)
 		if err != nil {
 			wac.Log.Errorf("Could not send presence: %+v", err)
 		}
-		wac.SetForceActiveDeliveryReceipts(false)
 	}
 }
 


### PR DESCRIPTION
#46 

experiments
- [ ] Does it have to do with `types.Presence(A|Una)vailable`? If so... maybe we can set a timer to set as available once every N hours for a short time just to be marked as an active client?