### PR TITLE
Remove wait command from whatupcore2/run.sh

### DIFF
--- a/whatupcore2/run.sh
+++ b/whatupcore2/run.sh
@@ -24,7 +24,3 @@ case $app_command in
         exec /whatupcore2 remove-user ${WHATUPCORE2_REMOVE_USER}
     ;;
 esac
-
-
-# Exit immediately when one of the background processes terminate.
-wait -n


### PR DESCRIPTION
Related to #103.

I just happened to notice that the `run.sh` file still has the `wait -n` command at the end which was only needed when we were using `tini` and `gcsfuse`. Now that `whatupcore2` is run synchronously using `exec` as becomes PID 1, there is no background process that we need to wait on.

Anyway we should deploy this PR to your test stack and do two deployments so that both the old revision and the new revision are using this updated `run.sh`.