### PR TITLE
Fix logic for enabling deletion protection for database instance

### DIFF
--- a/infrastructure/database.py
+++ b/infrastructure/database.py
@@ -25,7 +25,7 @@ sql_instance_settings = sql.DatabaseInstanceSettingsArgs(
     backup_configuration=backup_config,
     # Only disable disable protection if you are intentional
     # about wanting to delete the instance.
-    deletion_protection_enabled=False if is_prod_stack() else True,
+    deletion_protection_enabled=is_prod_stack(),
     ip_configuration=sql.DatabaseInstanceSettingsIpConfigurationArgs(
         allocated_ip_range=private_ip_address_range.name,
         # Allow BigQuery to connect to the DB via the SQL


### PR DESCRIPTION
I noticed this while I was destroying my dev stack and couldn't delete the database even though my stack is not a prod stack.