### PR TITLE
Enable running Pulumi via GitHub Actions for PRs and merge builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,67 +5,34 @@ on:
     branches: main
     paths:
       - infrastructure/**
-      - .github/workflows/lint-infra.yml
+      - .github/workflows/ci.yml
 
   pull_request:
     paths:
       - infrastructure/**
-      - .github/workflows/lint-infra.yml
+      - .github/workflows/ci.yml
 
-  workflow_dispatch:
-    inputs:
-      command:
-        description: up or destroy? (cannot run destroy if stack name is prod.)
-        default: "up"
-        required: true
-      stackName:
-        type: choice
-        required: true
-        description: Pulumi stack name
-        default: test
-        options:
-          - test
-          - prod
+concurrency:
+  group: ci_${{ github.ref }}
+  # Never cancel in-progress push builds as it could leave the
+  # infrastructure in a bad state.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read # Allows actions/checkout to read the repo.
   id-token: write
 
 jobs:
-  pulumi:
-    env:
-      PULUMI_COMMAND: preview
-      PULUMI_STACK_NAME: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  preview-or-deploy-test-infra:
+    if: github.base_ref == 'main'
+    uses: ./.github/workflows/pulumi.yml
+    secrets: inherit
+    with:
+      gh-environment: test
 
-      - name: Copy workflow_dispatch inputs
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          COMMAND_INPUT: ${{ github.event.inputs.command }}
-          STACK_NAME_INPUT: ${{ github.event.inputs.stackName }}
-        run: |-
-          echo "PULUMI_COMMAND=$COMMAND_INPUT" >> "$GITHUB_ENV"
-          echo "PULUMI_STACK_NAME=$STACK_NAME_INPUT" >> "$GITHUB_ENV"
-
-      - id: auth
-        name: "Authenticate to GCP"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: true
-          project_id: whatup-deploy
-          workload_identity_provider: "<example-workload-identity-provider>"
-
-      - id: gcloud
-        name: "gcloud"
-        run: |-
-          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
-
-      - name: Run pulumi
-        uses: pulumi/actions@v4
-        with:
-          command: ${{ env.PULUMI_COMMAND }}
-          stack-name: ${{ env.PULUMI_STACK_NAME }}
-          work-dir: infrastructure
-          comment-on-pr: ${{ github.event_name == 'pull_request' }}
+  preview-or-deploy-prod-infra:
+    if: github.base_ref == 'production'
+    uses: ./.github/workflows/pulumi.yml
+    secrets: inherit
+    with:
+      gh-environment: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: Infrastructure CI
+
+on:
+  push:
+    branches: main
+    paths:
+      - infrastructure/**
+      - .github/workflows/lint-infra.yml
+
+  pull_request:
+    paths:
+      - infrastructure/**
+      - .github/workflows/lint-infra.yml
+
+  workflow_dispatch:
+    inputs:
+      command:
+        description: up or destroy? (cannot run destroy if stack name is prod.)
+        default: "up"
+        required: true
+      stackName:
+        type: choice
+        required: true
+        description: Pulumi stack name
+        default: test
+        options:
+          - test
+          - prod
+
+permissions:
+  contents: read # Allows actions/checkout to read the repo.
+  id-token: write
+
+jobs:
+  pulumi:
+    env:
+      PULUMI_COMMAND: preview
+      PULUMI_STACK_NAME: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy workflow_dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          COMMAND_INPUT: ${{ github.event.inputs.command }}
+          STACK_NAME_INPUT: ${{ github.event.inputs.stackName }}
+        run: |-
+          echo "PULUMI_COMMAND=$COMMAND_INPUT" >> "$GITHUB_ENV"
+          echo "PULUMI_STACK_NAME=$STACK_NAME_INPUT" >> "$GITHUB_ENV"
+
+      - id: auth
+        name: "Authenticate to GCP"
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: true
+          project_id: whatup-deploy
+          workload_identity_provider: "<example-workload-identity-provider>"
+
+      - id: gcloud
+        name: "gcloud"
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+
+      - name: Run pulumi
+        uses: pulumi/actions@v4
+        with:
+          command: ${{ env.PULUMI_COMMAND }}
+          stack-name: ${{ env.PULUMI_STACK_NAME }}
+          work-dir: infrastructure
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-infra.yml
+++ b/.github/workflows/lint-infra.yml
@@ -21,3 +21,29 @@ jobs:
       - name: Lint
         run: make lint-ci
         working-directory: infrastructure
+
+  preview:
+    needs: lint
+    permissions:
+      contents: read # Allows actions/checkout to read the repo.
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: "Authenticate to GCP"
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: true
+          project_id: whatup-deploy
+          workload_identity_provider: "<example-workload-identity-provider>"
+
+      - id: gcloud
+        name: "gcloud"
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+
+      - uses: pulumi/actions@v4
+        with:
+          work-dir: infrastructure

--- a/.github/workflows/lint-infra.yml
+++ b/.github/workflows/lint-infra.yml
@@ -21,29 +21,3 @@ jobs:
       - name: Lint
         run: make lint-ci
         working-directory: infrastructure
-
-  preview:
-    needs: lint
-    permissions:
-      contents: read # Allows actions/checkout to read the repo.
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: auth
-        name: "Authenticate to GCP"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: true
-          project_id: whatup-deploy
-          workload_identity_provider: "<example-workload-identity-provider>"
-
-      - id: gcloud
-        name: "gcloud"
-        run: |-
-          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
-
-      - uses: pulumi/actions@v4
-        with:
-          work-dir: infrastructure

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -18,9 +18,9 @@ jobs:
         uses: "google-github-actions/auth@v2"
         with:
           create_credentials_file: true
-          project_id: ${{ secrets.PROJECT_ID }}
+          project_id: ${{ env.PROJECT_ID }}
           workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_POOL_ID}}/providers/github"
-          service_account: github-actions-service-account@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
+          service_account: github-actions-service-account@${{ env.PROJECT_ID }}.iam.gserviceaccount.com
 
       - id: gcloud
         name: "gcloud"

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -35,7 +35,7 @@ jobs:
           command: preview
           stack-name: ${{ env.PULUMI_STACK_NAME }}
           work-dir: infrastructure
-          comment-on-pr: true
+          comment-on-pr: false
 
       - name: Run pulumi up
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   pulumi:
+    environment: ${{ inputs.gh-environment }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -1,0 +1,45 @@
+name: Preview or update Pulumi app
+
+on:
+  workflow_call:
+    inputs:
+      gh-environment:
+        required: true
+        type: string
+
+jobs:
+  pulumi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: "Authenticate to GCP"
+        uses: "google-github-actions/auth@v2"
+        with:
+          create_credentials_file: true
+          project_id: ${{ secrets.PROJECT_ID }}
+          workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_POOL_ID}}/providers/github"
+          service_account: github-actions-service-account@${{ secrets.PROJECT_ID }}.iam.gserviceaccount.com
+
+      - id: gcloud
+        name: "gcloud"
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+
+      - name: Run pulumi preview
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: pulumi/actions@v4
+        with:
+          command: preview
+          stack-name: ${{ env.PULUMI_STACK_NAME }}
+          work-dir: infrastructure
+          comment-on-pr: true
+
+      - name: Run pulumi up
+        if: ${{ github.event_name == 'push' }}
+        uses: pulumi/actions@v4
+        with:
+          command: up
+          stack-name: ${{ env.PULUMI_STACK_NAME }}
+          work-dir: infrastructure

--- a/scripts/setup-workload-identity-pool.sh
+++ b/scripts/setup-workload-identity-pool.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${PROJECT_ID:-}" ]; then
+    echo "Please set PROJECT_ID and re-run."
+    exit 1
+fi
+
+REPO_OWNER="digital-witness-lab"
+REPO_NAME="whatup"
+REPO_SLUG="${REPO_OWNER}/${REPO_NAME}"
+
+echo "****************************"
+echo "This script only works when executed by a user who has admin-level privileges in the project ${PROJECT_ID}."
+echo "****************************"
+
+read -p "Press Enter to continue or Ctrl+c to quit..."
+
+gcloud iam workload-identity-pools create "github" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --display-name="GitHub Actions Pool"
+
+gcloud iam workload-identity-pools describe "github" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --format="value(name)"
+
+gcloud iam workload-identity-pools providers create-oidc "${REPO}" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --workload-identity-pool="github" \
+  --display-name="My GitHub repo Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+WORKLOAD_IDENTITY_POOL_ID=gcloud iam workload-identity-pools providers describe "${REPO}" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --workload-identity-pool="github" \
+  --format="value(name)"
+
+echo "Workload identity provider ${WORKLOAWORKLOAD_IDENTITY_POOL_IDD_ID_PROVIDER} created for project ${PROJECT_ID}."
+
+echo "Granting the ID provider access to GCP services..."
+

--- a/scripts/setup-workload-identity-pool.sh
+++ b/scripts/setup-workload-identity-pool.sh
@@ -17,31 +17,66 @@ echo "****************************"
 
 read -p "Press Enter to continue or Ctrl+c to quit..."
 
+SERVICE_ACCOUNT_NAME="github-actions-service-account"
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+gcloud iam service-accounts create "${SERVICE_ACCOUNT_NAME}" \
+  --project "${PROJECT_ID}"
+
 gcloud iam workload-identity-pools create "github" \
   --project="${PROJECT_ID}" \
   --location="global" \
-  --display-name="GitHub Actions Pool"
+  --display-name="GitHub Actions Pool" \
+  --description="Workload identity pool used for running Pulumi in GitHub Actions"
 
 gcloud iam workload-identity-pools describe "github" \
   --project="${PROJECT_ID}" \
   --location="global" \
   --format="value(name)"
 
-gcloud iam workload-identity-pools providers create-oidc "${REPO}" \
+gcloud iam workload-identity-pools providers create-oidc "${REPO_NAME}" \
   --project="${PROJECT_ID}" \
   --location="global" \
   --workload-identity-pool="github" \
-  --display-name="My GitHub repo Provider" \
+  --display-name="GitHub repo Provider" \
   --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
   --issuer-uri="https://token.actions.githubusercontent.com"
 
-WORKLOAD_IDENTITY_POOL_ID=gcloud iam workload-identity-pools providers describe "${REPO}" \
+WORKLOAD_IDENTITY_POOL_ID=gcloud iam workload-identity-pools providers describe "${REPO_NAME}" \
   --project="${PROJECT_ID}" \
   --location="global" \
   --workload-identity-pool="github" \
-  --format="value(name)"
+  --format="value(name)" 
 
-echo "Workload identity provider ${WORKLOAWORKLOAD_IDENTITY_POOL_IDD_ID_PROVIDER} created for project ${PROJECT_ID}."
+echo "****************************"
+echo "Granting the workload ID pool access to GCP services..."
+echo "****************************"
 
-echo "Granting the ID provider access to GCP services..."
+# First, allow authentications from the Workload Identity Pool to the service account.
+gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT_EMAIL}" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_ID}/attribute.repository/${REPO_SLUG}"
 
+function grant_role_to_service_account() {
+  role=$1
+
+  gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT_EMAIL}" \
+    --project="${PROJECT_ID}" \
+    --role="${role}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}"
+}
+
+grant_role_to_service_account "roles/artifactregistry.admin"
+grant_role_to_service_account "roles/bigquery.admin"
+grant_role_to_service_account "roles/cloudkms.admin"
+grant_role_to_service_account "roles/cloudsql.admin"
+grant_role_to_service_account "roles/compute.networkAdmin" # For VPC, firewall and other networking resources.
+grant_role_to_service_account "roles/iam.serviceAccountAdmin"
+grant_role_to_service_account "roles/run.admin" # Cloud Run.
+grant_role_to_service_account "roles/secretmanager.admin"
+grant_role_to_service_account "roles/storage.admin"
+
+echo "****************************"
+echo "Workload identity pool ${WORKLOAD_IDENTITY_POOL_ID} created for project ${PROJECT_ID}."
+echo "The workload identity pool has been granted access to the service account ${SERVICE_ACCOUNT_EMAIL}"
+echo "****************************"


### PR DESCRIPTION
This PR adds workflows that enable running `pulumi preview` and `pulumi up` for pull requests and push builds respectively.

But in order for those workflows to work, the following tasks need to be completed.

* [x] Run the new `setup-workload-identity-pool.sh` script for the `whatup-deploy` project @praneetloke 
  * The value of `WORKLOAD_IDENTITY_POOL_ID` for this project is `projects/226885687962/locations/global/workloadIdentityPools/github`.
* [ ] Run the new `setup-workload-identity-pool.sh` script for the `whatup-prod` project @mynameisfiber
  * Be sure to note the value of the `WORKLOAD_IDENTITY_POOL_ID` this prints at the very end.
* [ ] Create a [Pulumi access token](https://app.pulumi.com/account/tokens) for your account that has access to the Pulumi stacks for whatup infra @mynameisfiber
* [ ] Create two GitHub environments under the **Settings** tab for this repository -- one called `test` and the other `prod` @mynameisfiber
* [ ] Create the following environment variables in each of the environments @mynameisfiber
  * [ ] `PULUMI_STACK_NAME`
  * [ ] `PROJECT_ID` (it's just the name of the GCP project; i.e. `whatup-deploy` and `whatup-prod` respectively)
* [ ] Create the following secret variables in each of the environments @mynameisfiber
  * [ ] `WORKLOAD_IDENTITY_POOL_ID`
  * [ ] `PULUMI_ACCESS_TOKEN` (the token you created earlier; you may use the same token in both environments for test and prod.)
* [ ] Install the [Pulumi GitHub App](https://github.com/apps/pulumi) into your GitHub account and allow access to this repo so that it can add a PR comment whenever a `pulumi preview` is run for PRs giving insight into the resources being modified.
