### PR TITLE
Limit log size on VMs

### DIFF
--- a/infrastructure/container_vm.py
+++ b/infrastructure/container_vm.py
@@ -23,6 +23,20 @@ install_cloud_ops_agent = """
 echo "Installing Google Cloud Ops Agent..."
 curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
 bash add-google-cloud-ops-agent-repo.sh --also-install
+
+echo "Setting docker log size"
+cat <<EOF > /etc/docker/daemon.json
+{
+    "live-restore": true,
+    "log-opts": {
+        "tag": "{{.Name}}"
+        "max-size": "100m"
+    },
+    "storage-driver": "overlay2",
+    "mtu": 1460
+}
+EOF
+systemctl restart docker
 """.strip()
 
 


### PR DESCRIPTION
We're getting errors from logs taking up too much space on device

```
time="2024-02-26T13:32:10.756497818Z" level=error msg="Error writing log message" driver=json-file error="error writing log entry: write /var/lib/docker/containers/b7934d10610c4e4519652f7c66327cc02f00c5f0f2e7bdf3ab47f80810b87dcb/b7934d10610c4e4519652f7c66327cc02f00c5f0f2e7bdf3ab47f80810b87dcb-json.log: no space left on device" message="
```