### PR TITLE
Duplicate groups in group selection

### DIFF
--- a/whatupcore2/pkg/whatupcore2/protoconversions.go
+++ b/whatupcore2/pkg/whatupcore2/protoconversions.go
@@ -149,6 +149,7 @@ func GroupInfoToProto(gi *types.GroupInfo, device *store.Device) *pb.GroupInfo {
 		DisappearingTimer: gi.GroupEphemeral.DisappearingTimer,
 
 		IsCommunityDefaultGroup: gi.IsAnnounce,
+        IsCommunity:             gi.IsParent,
 
 		ParticipantVersionId: gi.ParticipantVersionID,
 		Participants:         participants,

--- a/whatupcore2/pkg/whatupcore2/whatupcoreserver.go
+++ b/whatupcore2/pkg/whatupcore2/whatupcoreserver.go
@@ -445,7 +445,6 @@ func (s *WhatUpCoreServer) GetCommunityInfo(pJID *pb.JID, server pb.WhatUpCore_G
 		communityInfo.Participants = mergeGroupParticipants(communityInfo.Participants, communityParticipants)
 	}
 	communityInfoProto := GroupInfoToProto(communityInfo, session.Client.Store)
-	communityInfoProto.IsCommunity = true
 	if err := server.Send(AnonymizeInterface(session.Client.anonLookup, communityInfoProto)); err != nil {
 		s.log.Errorf("Could not send message to client: %v", err)
 		return nil


### PR DESCRIPTION
resolves #133 

Comes from a bug where `GroupInfo.IsCommunity` wasn't being set. This can be set in the GroupInfo proto conversion to make sure it is always set.

In addition, we filter out `IsCommunity == true` groups in the group selection.